### PR TITLE
Skip checking for submission limit if user.unlimited=true

### DIFF
--- a/db/migrate/20150306162524_add_unlimited_to_users.rb
+++ b/db/migrate/20150306162524_add_unlimited_to_users.rb
@@ -1,5 +1,5 @@
 class AddUnlimitedToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :unlimited, :boolean
+    add_column :users, :unlimited, :boolean, default: false
   end
 end

--- a/db/migrate/20150306162524_add_unlimited_to_users.rb
+++ b/db/migrate/20150306162524_add_unlimited_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnlimitedToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :unlimited, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150306162424) do
+ActiveRecord::Schema.define(version: 20150306162524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -300,6 +300,7 @@ ActiveRecord::Schema.define(version: 20150306162424) do
     t.string   "stripe_subscription_token"
     t.integer  "plan_id"
     t.datetime "stripe_current_period_end"
+    t.boolean  "unlimited"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -300,7 +300,7 @@ ActiveRecord::Schema.define(version: 20150306162524) do
     t.string   "stripe_subscription_token"
     t.integer  "plan_id"
     t.datetime "stripe_current_period_end"
-    t.boolean  "unlimited"
+    t.boolean  "unlimited"                  default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/lib/tasks/periodic_importer.rake
+++ b/lib/tasks/periodic_importer.rake
@@ -1,7 +1,7 @@
 namespace :importer do
   task :periodic => :environment do
     OdkSfLegacy::Mapping.where(active: true, enabled: true).each do |mapping|
-      if mapping.user.plan.job_limit > mapping.user.legacy_count
+      if mapping.user.plan.job_limit > mapping.user.legacy_count || mapping.user.unlimited
         Sidekiq::Client.enqueue OdkSfLegacy::OdkToSalesforce::Dispatcher, mapping.id, 50
       end
     end


### PR DESCRIPTION
 This will skip the check for job_limit on the `user.plan` if `user.unlimited=true`.

Note that I've backdated the mirgation file so that it doesn't create issues when we next release `develop` to `master`.

@stuartc , check it out. Do I need to expose "unlimited" in the attribute watcher or something? How does that `user.unlimited` get to the importer rake?