### PR TITLE
Typo in payload decoding

### DIFF
--- a/app/models/submission/payload_decoding.rb
+++ b/app/models/submission/payload_decoding.rb
@@ -6,8 +6,8 @@ class Submission::PayloadDecoding
 
   def perform(record_id)
     record = Submission::Record.find(record_id)
-    record.raw_destination_payload = integration_klass_for(record).
-      decode(record.destination_payload)
+    record.destination_payload = integration_klass_for(record).
+      decode(record.raw_destination_payload)
     record.save!
     
     # only for PUSH destination integrations. Pulls can be handled by storing destination payloads for collection.


### PR DESCRIPTION
I think that in line 8 we should set the "destination_payload" to the output of "decode(record.raw_destination_payload)" instead of setting the "raw_destination_payload" to the output of "decode(destination_payload)". This is likely just a typo in the original code.

@stuartc @fteem 